### PR TITLE
fix video player current time and total duration

### DIFF
--- a/src/lmt/player.html
+++ b/src/lmt/player.html
@@ -12,6 +12,7 @@
 
 		<script>
 			const { ipcRenderer } = require('electron');
+			const fmtDuration = require('format-duration');
 
 			$(function(){
 				var t=window.location.href.split('#'), u=t[1], uu = t[1].split('/'), f=uu[uu.length - 1];
@@ -42,12 +43,9 @@
 					var a = Math.round((video.currentTime / video.duration) * 1000) / 1000, b = $('#progressbar').width() * a;
 					$('#progressbar .position').css({ left: b });
 
-					var h = Math.round(video.currentTime / 3600), m = Math.round(video.currentTime / 60) % 60, s = Math.round(video.currentTime % 60),
-						o = (h>0?h+':':'')+(m>9?'':'0')+m+':'+(s>9?'':'0')+s;
+					var ct = fmtDuration(video.currentTime * 1000), td = fmtDuration(video.duration * 1000),
+					o = ct + '  /  ' + td;
 
-					var h = Math.round(video.duration / 3600), m = Math.round(video.duration / 60) % 60, s = Math.round(video.duration % 60);
-					
-					o += '  /  ' + (h>0?h+':':'')+(m>9?'':'0')+m+':'+(s>9?'':'0')+s;
 					$('.current_time').html(o);
 				}, false);
 

--- a/src/package.json
+++ b/src/package.json
@@ -20,6 +20,7 @@
     "electron-is-dev": "^0.3.0",
     "electron-settings": "^3.1.2",
     "fluent-ffmpeg": "^2.1.2",
+    "format-duration": "^1.0.0",
     "fs-extra": "^4.0.1",
     "init": "^0.1.2",
     "liveme-api": "^1.2.2",


### PR DESCRIPTION
When `video.currentTime` hits 31:00, it jumps to 1:30:00, also happens with `video.duration` if it's over 31 minutes.

This PR uses a small library to convert `video.currentTime` and `video.duration` to a duration string.

Current
![](https://i.imgur.com/IUv1pb4.png)

Fixed
![](https://i.imgur.com/Nbj6bPM.png)